### PR TITLE
fill_tool_path - population of ToolPathPoint locations

### DIFF
--- a/include/tool_path.h
+++ b/include/tool_path.h
@@ -10,9 +10,9 @@ namespace computational_geometry {
 typedef std::array<float, 3> Vector3D;
 
 /// Tool path point data class.
-class ToolPathPointData {
+class ToolPathPointMetaData {
   public:
-    ToolPathPointData() {}
+    ToolPathPointMetaData() {}
     // TODO : define this class.
 };
 
@@ -20,13 +20,19 @@ class ToolPathPointData {
 class ToolPathPoint {
   public:
     ToolPathPoint() {}
+
+    /// @brief set index of point this point has inherited location from.
+    void setLocationIndex(int point_index);
+
+    /// @brief get point index for location inherited from.
+    int getLocationIndex() const { return m_point_location_index; }
   
   private:
-    // Actual 3D point
-    Vector3D* location{nullptr};
+    // Index of point (in ToolPath::m_points) this point has inherited location from (maybe the same point).
+    int m_point_location_index{0};
 
     // Data associated with this path point.
-    std::optional<ToolPathPointData> m_data{std::nullopt};
+    std::optional<ToolPathPointMetaData> m_data{std::nullopt};
 };
 
 /// Top-level class for ToolPath object.

--- a/src/tool_path.cc
+++ b/src/tool_path.cc
@@ -1,16 +1,66 @@
 #include <tool_path.h>
 
+#include <assert.h>
+
 namespace computational_geometry {
+
+void ToolPathPoint::setLocationIndex(int point_index) {
+  assert(point_index >= 0);
+  assert(point_index >= m_point_location_index);
+  m_point_location_index = point_index;
+}
 
 ToolPath::ToolPath(int n_points) : m_points(n_points) {
 }
 
 void ToolPath::setLocation(int point_index, const Vector3D& location) {
-  // TODO: implement this function
+  auto iter_range = m_locations.equal_range(point_index);
+  if (m_locations.empty() || iter_range.second == m_locations.begin()) {
+    // This is initial point of trajectory, it must always be at index = 0
+    assert(point_index == 0);
+  } else {
+    if (iter_range.first == m_locations.end()) {
+      // Get the last existing location.
+      int last_location_index = m_locations.rbegin()->first;
+      assert(last_location_index < point_index);
+
+      // Annotate location indices for [last_location_index, point_index) interval of points
+      for(int i = last_location_index + 1; i < point_index; i++) {
+        m_points[i].setLocationIndex(last_location_index);
+      }
+    } else {
+      auto iter_from = iter_range.first;
+      int location_index_from = iter_from->first;
+      auto iter_to = iter_range.second;
+      int location_index_to = iter_to->first;
+      assert(point_index >= location_index_from);
+      assert(point_index <= location_index_to);
+
+      // Annotate location indices for [point_index, location_index_to) interval of points
+      for(int i = point_index + 1; i < location_index_to; i++) {
+        m_points[i].setLocationIndex(point_index);
+      }
+    }
+  }
+
+  // Insert location into the map.
+  m_locations[point_index] = location;
+
+  // Set location index for the point.
+  m_points[point_index].setLocationIndex(point_index);
 }
 
 void ToolPath::finalizeLocations() {
-  // TODO: implement this function
+  // Get the last existing location.
+  int last_location_index = m_locations.rbegin()->first;
+  int n_points = m_points.size();
+  assert(last_location_index < n_points);
+  assert(m_points[last_location_index].getLocationIndex() == last_location_index);
+
+  // Annotate location indices for [last_location_index, point_index interval of points)
+  for(int i = last_location_index + 1; i < n_points; i++) {
+    m_points[i].setLocationIndex(last_location_index);
+  }
 }
   
 } // namespace computational_geometry


### PR DESCRIPTION
Results for ToolPath creation (no meta data yet, only points) on my laptop:

vscode ➜ /workspaces/Computational-Geometry-Tests (finalize_tool_path_creation ✗) $ ./install/bin/tool_path_test
Current memory allocated by program:
VM: 5908 kB; RSS: 1576 kB
Building ToolPath object...
ToolPath object created, elapsed_time = 13.7146 sec
Current memory allocated by program:
VM: 1.10568e+06 kB; RSS: 1.10342e+06 kB
